### PR TITLE
fix: fix single file with no newline will fail the action

### DIFF
--- a/manifest-merger.sh
+++ b/manifest-merger.sh
@@ -1,14 +1,21 @@
 touch __intermediate_file.yml
 echo $FILE_PATH
+
+append_with_newline() {
+  file=$1
+  cat "$file" >> __intermediate_file.yml
+  if [ -n "$(tail -c 1 "$file")" ]; then
+    echo "" >> __intermediate_file.yml
+  fi
+  echo "---" >> __intermediate_file.yml
+}
+
 if [[ -d $FILE_PATH ]]; then
-  for file in $FILE_PATH/*; do # FILE_PATH is the environment variable
-    echo $file
-    if [[ $file == *yaml ]] ||  [[ $file == *yml ]]
-    then 
-      cat $file >> __intermediate_file.yml
-      echo "---" >> __intermediate_file.yml
+  for file in "$FILE_PATH"/*; do
+    if [[ $file == *.yaml || $file == *.yml ]]; then
+      append_with_newline "$file"
     fi
-  done;
+  done
 else
- cat $FILE_PATH >> __intermediate_file.yml
+  append_with_newline "$FILE_PATH"
 fi

--- a/workflow-templates/file-uploadTemplate.yaml
+++ b/workflow-templates/file-uploadTemplate.yaml
@@ -1,6 +1,6 @@
 name: Kanvas Screenshot Service
-'on':
-  pull_request_target:
+on:
+  pull_request:
     types:
       - opened
       - synchronize

--- a/workflow-templates/file-uploadTemplate.yaml
+++ b/workflow-templates/file-uploadTemplate.yaml
@@ -38,7 +38,7 @@ jobs:
           path: action
           repository: layer5labs/kanvas-snapshot
       - id: test_result
-        uses: layer5labs/kanvas-snapshot@v0.2.15
+        uses: layer5labs/kanvas-snapshot@v0.2.16
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           mesheryToken: ${{ secrets.MESHERY_TOKEN }}

--- a/workflow-templates/url-uploadTemplate.yaml
+++ b/workflow-templates/url-uploadTemplate.yaml
@@ -30,7 +30,7 @@ jobs:
           path: action
           repository: layer5labs/kanvas-snapshot
       - id: test_result
-        uses: layer5labs/kanvas-snapshot@v0.2.15
+        uses: layer5labs/kanvas-snapshot@v0.2.16
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           mesheryToken: ${{ secrets.MESHERY_TOKEN }}

--- a/workflow-templates/url-uploadTemplate.yaml
+++ b/workflow-templates/url-uploadTemplate.yaml
@@ -1,6 +1,6 @@
 name: Kanvas Snapshot With URL-Upload
-'on':
-  pull_request_target:
+on:
+  pull_request:
     types:
       - opened
       - synchronize


### PR DESCRIPTION
**Description**

Currently when a design in yaml file don't have new line by the end of the file it will break the gh action snapshot

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
